### PR TITLE
Fixed getNumNormalChars(). Tests pass. But check with UI.

### DIFF
--- a/src/textselect/TextSelectionLine.cpp
+++ b/src/textselect/TextSelectionLine.cpp
@@ -79,7 +79,7 @@ long TextSelectionLine::getNextSelectionStart(long columnId)
     long fromColumn = (*it)->getFromColumn();
     if(fromColumn >= columnId)
     {
-      return fromColumn;
+      return fromColumn - columnId;
     }
   }
 


### PR DESCRIPTION
No bigger algorithm change done. Because the reported bug (testcase_41/42) also occurs in Linux DiffUtils and in TotalCommander diff it can be assumed that is due to the mathematics of Myers original algorithm - and I will not be able to change it.